### PR TITLE
feat: make twitter optional with telegram

### DIFF
--- a/server/bin/check-x-login
+++ b/server/bin/check-x-login
@@ -15,29 +15,28 @@ async function loginTwitter() {
   console.log("Loading Twitter environment variables...");
   const scraper = new Scraper();
   console.log("Logging in to Twitter...");
+  let errMessage = "";
   if (!process.env.TWITTER_USERNAME) {
-    console.error("TWITTER_USERNAME is not set");
-    process.exit(1);
+    errMessage += "TWITTER_USERNAME is not set ";
   }
   if (!process.env.TWITTER_PASSWORD) {
-    console.error("TWITTER_PASSWORD is not set");
-    process.exit(1);
+    errMessage += "TWITTER_PASSWORD is not set ";
   }
   if (!process.env.TWITTER_API_KEY) {
-    console.error("TWITTER_API_KEY is not set");
-    process.exit(1);
+    errMessage += "TWITTER_API_KEY is not set ";
   }
   if (!process.env.TWITTER_API_SECRET_KEY) {
-    console.error("TWITTER_API_SECRET_KEY is not set");
-    process.exit(1);
+    errMessage += "TWITTER_API_SECRET_KEY is not set ";
   }
   if (!process.env.TWITTER_ACCESS_TOKEN) {
-    console.error("TWITTER_ACCESS_TOKEN is not set");
-    process.exit(1);
+    errMessage += "TWITTER_ACCESS_TOKEN is not set ";
   }
   if (!process.env.TWITTER_ACCESS_TOKEN_SECRET) {
-    console.error("TWITTER_ACCESS_TOKEN_SECRET is not set");
-    process.exit(1);
+    errMessage += "TWITTER_ACCESS_TOKEN_SECRET is not set ";
+  }
+  if (errMessage) {
+    console.error(`Missing twitter configuraiton: ${errMessage}`);
+    throw new Error(errMessage);
   }
   await scraper.login(
     process.env.TWITTER_USERNAME,
@@ -70,13 +69,17 @@ async function main() {
     console.log(
       "[INFO] twitter-cookies.json does not exist, creating a new one..."
     );
-    const cookies = await loginTwitter();
-    // store the cookies in twitter-cookies.json in the cookies property
-    fs.writeFileSync(
-      twitterCookiesPath,
-      JSON.stringify({ cookies: cookies.map((cookie) => cookie.toString()) })
-    );
-    console.log("Twitter cookies saved to:", twitterCookiesPath);
+    try {
+      const cookies = await loginTwitter();
+      // store the cookies in twitter-cookies.json in the cookies property
+      fs.writeFileSync(
+        twitterCookiesPath,
+        JSON.stringify({ cookies: cookies.map((cookie) => cookie.toString()) })
+      );
+      console.log("[INFO] Twitter cookies saved to:", twitterCookiesPath);
+    } catch (err) {
+      console.log("[WARN] Unable to connect to twitter ", err);
+    }
   }
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,7 +14,6 @@ import cookieParser from "cookie-parser";
 import githubRouter from "./routes/github.js";
 import { AnyType } from "./utils.js";
 import { isHttpError } from "http-errors";
-import { TwitterService } from "./services/twitter.service.js";
 
 // Convert ESM module URL to filesystem path
 const __filename = fileURLToPath(import.meta.url);
@@ -93,15 +92,6 @@ app.listen(port, async () => {
 
     const ngrokUrl = ngrokService.getUrl()!;
     console.log("NGROK URL:", ngrokUrl);
-
-    const twitterInstance = TwitterService.getInstance();
-    await twitterInstance.start();
-    const me = await twitterInstance.me;
-    services.push(twitterInstance);
-    if (!me) {
-      throw new Error("Twitter account not found");
-    }
-    console.log("Twitter Bot Profile:", JSON.stringify(me, null, 2));
 
     // Initialize Telegram bot and set webhook
     await telegramService.start();

--- a/server/src/services/telegram.service.ts
+++ b/server/src/services/telegram.service.ts
@@ -22,6 +22,8 @@ export class TelegramService extends BaseService {
   private bot: Bot;
   private webhookUrl: string;
   private elizaService: ElizaService;
+  private nGrokService: NgrokService;
+  private twitterService?: TwitterService;
 
   private constructor(webhookUrl?: string) {
     super();
@@ -82,9 +84,22 @@ export class TelegramService extends BaseService {
         console.error("Telegram bot error:", error);
       });
       await this.elizaService.start();
+      // required when starting server for telegram webooks
+      this.nGrokService = await NgrokService.getInstance();
+      try {
+        this.twitterService = await TwitterService.getInstance();
+        console.log(
+          "Twitter Bot Profile:",
+          JSON.stringify(this.twitterService.me, null, 2)
+        );
+      } catch (err) {
+        console.log(
+          "[WARN] [telegram.service] Unable to use twitter. Functionality will be disabled",
+          err
+        );
+      }
 
       this.bot.command("mint", async (ctx) => {
-        const ngrokURL = await NgrokService.getInstance().getUrl();
         try {
           ctx.reply("Minting your token...");
           const tokenPath = getTokenMetadataPath();
@@ -132,48 +147,51 @@ You can view the token page below (it takes a few minutes to be visible)`,
               parse_mode: "HTML",
             }
           );
-          const twitterClient = await TwitterService.getInstance().getScraper();
-          const twitterBotInfo = await twitterClient.me();
-          await ctx.reply(
-            `🐦 Posting a tweet about the new token...\n\n` +
-              `Twitter account details:\n<pre lang="json"><code>${JSON.stringify(
-                twitterBotInfo,
-                null,
-                2
-              )}</code></pre>`,
-            {
-              parse_mode: "HTML",
-            }
-          );
-          const claimURL = `${process.env.NEXT_PUBLIC_HOSTNAME}/claim/${tokenData.address}`;
-          const botUsername = twitterBotInfo?.username;
-          console.log("botUsername:", botUsername);
-          console.log("claimURL:", claimURL);
-          const slug =
-            Buffer.from(claimURL).toString("base64url") +
-            ":" +
-            Buffer.from(botUsername!).toString("base64url");
-          console.log("slug:", slug);
-          const cardURL = `${ngrokURL}/auth/twitter/card/${slug}/index.html`;
-          console.log("cardURL:", cardURL);
-          const twtRes = await twitterClient.sendTweet(
-            `I just minted a token on Base using Wow!\nThe ticker is $${tokenData.symbol}\nClaim early alpha here: ${cardURL}`
-          );
-          if (twtRes.ok) {
-            const tweetId = (await twtRes.json()) as AnyType;
-            console.log("Tweet posted successfully:", tweetId);
-            const tweetURL = `https://twitter.com/${twitterBotInfo?.username}/status/${tweetId?.data?.create_tweet?.tweet_results?.result?.rest_id}`;
-            console.log("Tweet URL:", tweetURL);
+          if (this.twitterService) {
+            const twitterBotInfo = this.twitterService.me;
+            const twitterClient = this.twitterService.getScraper();
+            const ngrokURL = this.nGrokService.getUrl();
             await ctx.reply(
-              `Tweet posted successfully!\n\n` +
-                `🎉 Tweet details: ${tweetURL}`,
+              `🐦 Posting a tweet about the new token...\n\n` +
+                `Twitter account details:\n<pre lang="json"><code>${JSON.stringify(
+                  twitterBotInfo,
+                  null,
+                  2
+                )}</code></pre>`,
               {
                 parse_mode: "HTML",
               }
             );
-          } else {
-            console.error("Failed to post tweet:", await twtRes.json());
-            await ctx.reply("Failed to post tweet");
+            const claimURL = `${process.env.NEXT_PUBLIC_HOSTNAME}/claim/${tokenData.address}`;
+            const botUsername = twitterBotInfo?.username;
+            console.log("botUsername:", botUsername);
+            console.log("claimURL:", claimURL);
+            const slug =
+              Buffer.from(claimURL).toString("base64url") +
+              ":" +
+              Buffer.from(botUsername!).toString("base64url");
+            console.log("slug:", slug);
+            const cardURL = `${ngrokURL}/auth/twitter/card/${slug}/index.html`;
+            console.log("cardURL:", cardURL);
+            const twtRes = await twitterClient.sendTweet(
+              `I just minted a token on Base using Wow!\nThe ticker is $${tokenData.symbol}\nClaim early alpha here: ${cardURL}`
+            );
+            if (twtRes.ok) {
+              const tweetId = (await twtRes.json()) as AnyType;
+              console.log("Tweet posted successfully:", tweetId);
+              const tweetURL = `https://twitter.com/${twitterBotInfo?.username}/status/${tweetId?.data?.create_tweet?.tweet_results?.result?.rest_id}`;
+              console.log("Tweet URL:", tweetURL);
+              await ctx.reply(
+                `Tweet posted successfully!\n\n` +
+                  `🎉 Tweet details: ${tweetURL}`,
+                {
+                  parse_mode: "HTML",
+                }
+              );
+            } else {
+              console.error("Failed to post tweet:", await twtRes.json());
+              await ctx.reply("Failed to post tweet");
+            }
           }
         } catch (error) {
           if (isAxiosError(error)) {


### PR DESCRIPTION
If twitter configuration is missing, errors will be logged but the server will still start and the telegram service won't have the ability to post/use twitter for context.

## Description

<!-- Describe your changes in detail -->

The twitter service is optionally attached to the telegram service so it can use it to post/retrieve context if it's valid. The script that persists cookies from twitter no longer exits the process and only logs an error. The logging of the twitter profile information no longer happens on server start and is moved into the telegram service.

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style update
- [ ] ♻️ Code refactor
- [x] 🔧 Configuration changes

## How Has This Been Tested?
I only tested that it starts successfully w/o config, I haven't tested that it still works when configured.

<!-- Describe how you tested your changes -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)

<!-- Add screenshots of your changes -->

## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link related issues below. Insert the issue link or reference -->
